### PR TITLE
Dev renders

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in frontco.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
-gem 'rspec', '~> 3.0'
-gem 'rubocop'
+group :development do
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
+
+  gem 'rubocop'
+  gem 'rubocop-rake'
+  gem 'rubocop-rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.13.1)
+      rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.3.0)
 
@@ -52,6 +56,8 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop
+  rubocop-rake
+  rubocop-rspec
 
 BUNDLED WITH
    2.2.22

--- a/frontco.gemspec
+++ b/frontco.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/frontco/renders/base_render.rb
+++ b/lib/frontco/renders/base_render.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Frontco
+  module Renders
+    # Base abstract class for HTML, Pug and others render classes
+    class BaseRender
+      # creating paired tags
+      Frontco::Tags::PAIRED_TAGS.each do |tag|
+        define_method(tag) do |text = '', **attrs, &subtags|
+          create_paired_tag(tag, text, **attrs, &subtags)
+        end
+      end
+
+      # creating singleton tags
+      Frontco::Tags::SINGLETON_TAGS.each do |tag|
+        define_method(tag) do |**attrs|
+          create_singleton_tag(tag, **attrs)
+        end
+      end
+
+      protected
+
+      def create_paired_tag(tag, text, **attrs, &subtags)
+        raise NotImplemenentedError,
+              "You need implement create_paired_tag(#{tag}, #{text}, **#{attrs}, &#{subtags})"
+      end
+
+      def create_singleton_tag(tag, **attrs)
+        raise NotImplemenentedError,
+              "You need implement create_singleton_tag(#{tag}, **#{attrs})"
+      end
+    end
+  end
+end

--- a/spec/frontco/tags_spec.rb
+++ b/spec/frontco/tags_spec.rb
@@ -2,10 +2,10 @@
 
 RSpec.describe Frontco::Tags do
   it 'Has a paired tags' do
-    expect(Frontco::Tags::PAIRED_TAGS).not_to be nil
+    expect(Frontco::Tags::PAIRED_TAGS).not_to be_nil
   end
 
   it 'Has a singleton tags' do
-    expect(Frontco::Tags::SINGLETON_TAGS).not_to be nil
+    expect(Frontco::Tags::SINGLETON_TAGS).not_to be_nil
   end
 end

--- a/spec/frontco_spec.rb
+++ b/spec/frontco_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe Frontco do
   it 'has a version number' do
-    expect(Frontco::VERSION).not_to be nil
+    expect(Frontco::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
### Functionality
- Added `BaseRender` class
- Method generation for BaseRender, grounded on `Frontco::Tags::PAIRED_TAGS` and `Frontco::Tags::SINGLETON_TAGS`
- New abstract protected methods `create_paired_tag` and `create_singleton_tag`

### Other
new cops for rubocop:
  - rubocop-rake
  - rubocop-rspec

and configuration for RuboCop(_.rubocop.yml_)